### PR TITLE
Added: markup extension

### DIFF
--- a/README-WPF.md
+++ b/README-WPF.md
@@ -47,6 +47,14 @@ You can also work with existing ContentControl based controls, like Button, with
         TextElement.FontFamily="pack://application:,,,/FontAwesome.WPF;component/#FontAwesome"/>
 ```
 
+Or use markup extension
+
+```xaml
+<Button Content="{fa:FontAwesome Flag}" TextElement.FontFamily="pack://application:,,,/FontAwesome.WPF;component/#FontAwesome"/>
+
+<TextBlock Text="{fa:FontAwesome Flag}" FontFamily="pack://application:,,,/FontAwesome.WPF;component/#FontAwesome"/>
+``` 
+
 > VS2013 XAML Designer has issues when using fonts embedded in another assembly (like this scenario), which prevents it to dispaly the glyph properly.  
 You could either grab a copy of TTF font file and include it in you Project as a Resource, so to use it in FontFamily, or you could follow the advices proposed in this [StackOverflow thread](http://stackoverflow.com/questions/29615572/visual-studio-designer-isnt-displaying-embedded-font/29636373#29636373). 
 

--- a/src/WPF/FontAwesome.WPF/FontAwesomeExtension.cs
+++ b/src/WPF/FontAwesome.WPF/FontAwesomeExtension.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Windows.Markup;
+
+namespace FontAwesome.WPF
+{
+    /// <summary>
+    /// Markup extension for easy converting from icon enum to string
+    /// </summary>
+    public class FontAwesomeExtension : MarkupExtension
+    {
+        /// <summary>
+        /// Icon.
+        /// </summary>
+        public FontAwesomeIcon Icon { get; set; }
+
+        public FontAwesomeExtension()
+        {
+        }
+
+
+        public FontAwesomeExtension(FontAwesomeIcon icon)
+        {
+            this.Icon = icon;
+        }
+
+        public override object ProvideValue(IServiceProvider serviceProvider)
+        {
+            return char.ConvertFromUtf32((int)Icon);
+        }
+    }
+}


### PR DESCRIPTION
Markup extention to convert from FontAwesomeIcon to string without bindings. Useful for styles and document element such Run, etc.

Example: 
```xaml
<TextBlock>
  Info <Run Text="{fa:FontAwesome InfoCircle}" FontFamily="pack://application:,,,/FontAwesome.WPF;component/#FontAwesome"/>
</TextBlock>
```